### PR TITLE
Send ruff's stderr to `os.devnull`

### DIFF
--- a/mdformat_ruff/__init__.py
+++ b/mdformat_ruff/__init__.py
@@ -17,5 +17,7 @@ def format_python(unformatted: str, _info_str: str) -> str:
     :rtype: str
     """
     return subprocess.check_output(
-        [find_ruff_bin(), "format", "-"], input=unformatted.encode()
+        [find_ruff_bin(), "format", "-"],
+        input=unformatted.encode(),
+        stderr=subprocess.DEVNULL,
     ).decode()


### PR DESCRIPTION
Inspired by discussion here https://github.com/executablebooks/mdformat/issues/435

IMO error output from commands mdformat calls in a subprocess should not be shown to the user.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Suppressed error messages during the execution of the Python formatting command, enhancing user experience by reducing unnecessary output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->